### PR TITLE
Made item tracking more robust

### DIFF
--- a/Assets/Resources/Rooms/A10.prefab
+++ b/Assets/Resources/Rooms/A10.prefab
@@ -1505,6 +1505,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1092644354055271896}
   - component: {fileID: 1092644354055271897}
+  - component: {fileID: 8426866164617817570}
   m_Layer: 0
   m_Name: A10
   m_TagString: RoomData
@@ -1547,6 +1548,19 @@ MonoBehaviour:
   liveTexture: {fileID: 2800000, guid: 35ca94fe734188c4eb6af96041795733, type: 3}
   baseTexture: {fileID: 2800000, guid: b4a957a5b266c4b4ca2279863992dba8, type: 3}
   level: 8
+--- !u!114 &8426866164617817570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092644354055271898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c33866761087e24597a09ba7f452f29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  roomName: 3
 --- !u!1 &1868137330611909199
 GameObject:
   m_ObjectHideFlags: 0
@@ -1664,7 +1678,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec393468e892e1e48b9a676ef844c964, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  room: 2
+  room: 4
   direction: 0
 --- !u!1 &4816219909515090297
 GameObject:
@@ -1769,7 +1783,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec393468e892e1e48b9a676ef844c964, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  room: 0
+  room: 2
   direction: 1
 --- !u!1 &5516189207880663904
 GameObject:

--- a/Assets/Resources/Rooms/A11.prefab
+++ b/Assets/Resources/Rooms/A11.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1092644354055271896}
   - component: {fileID: 1092644354055271897}
+  - component: {fileID: 856009460084931081}
   m_Layer: 0
   m_Name: A11
   m_TagString: RoomData
@@ -50,6 +51,19 @@ MonoBehaviour:
   liveTexture: {fileID: 2800000, guid: 35ca94fe734188c4eb6af96041795733, type: 3}
   baseTexture: {fileID: 2800000, guid: b4a957a5b266c4b4ca2279863992dba8, type: 3}
   level: 1
+--- !u!114 &856009460084931081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092644354055271898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c33866761087e24597a09ba7f452f29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  roomName: 4
 --- !u!1 &1868137330611909199
 GameObject:
   m_ObjectHideFlags: 0
@@ -277,7 +291,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec393468e892e1e48b9a676ef844c964, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  room: 1
+  room: 3
   direction: 1
 --- !u!1 &5516189207880663904
 GameObject:

--- a/Assets/Resources/Rooms/qasmoke.prefab
+++ b/Assets/Resources/Rooms/qasmoke.prefab
@@ -1269,6 +1269,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1092644354055271896}
   - component: {fileID: 1092644354055271897}
+  - component: {fileID: 5106327114745439933}
   m_Layer: 0
   m_Name: qasmoke
   m_TagString: RoomData
@@ -1308,6 +1309,19 @@ MonoBehaviour:
   liveTexture: {fileID: 2800000, guid: 35ca94fe734188c4eb6af96041795733, type: 3}
   baseTexture: {fileID: 2800000, guid: b4a957a5b266c4b4ca2279863992dba8, type: 3}
   level: 8
+--- !u!114 &5106327114745439933
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1092644354055271898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c33866761087e24597a09ba7f452f29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  roomName: 0
 --- !u!1 &1868137330611909199
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/Room.cs
+++ b/Assets/Scripts/Core/Room.cs
@@ -2,6 +2,8 @@ namespace Com.Technitaur.GreenBean.Core
 {
     public enum Room
     {
+        qasmoke,
+        Intro,
         A09,
         A10,
         A11,

--- a/Assets/Scripts/Core/RoomData.cs
+++ b/Assets/Scripts/Core/RoomData.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+
+namespace Com.Technitaur.GreenBean.Core
+{
+    public class RoomData : MonoBehaviour
+    {
+        public Room RoomName { get { return roomName; } }
+        
+        [SerializeField] private Room roomName = Room.A09;
+    }
+}

--- a/Assets/Scripts/Core/RoomData.cs.meta
+++ b/Assets/Scripts/Core/RoomData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c33866761087e24597a09ba7f452f29
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/SceneManagement/RoomLoader.cs
+++ b/Assets/Scripts/Core/SceneManagement/RoomLoader.cs
@@ -7,7 +7,6 @@ namespace Com.Technitaur.GreenBean.Core
         public static void Load(Room room, Direction direction, GameObject player)
         {
             player.SetActive(false);
-            Debug.Log("Loading room...");
             UnloadAll();
             InstantiateRoomPrefab(room);
             SetPlayerPosition(player, direction);
@@ -38,14 +37,13 @@ namespace Com.Technitaur.GreenBean.Core
 
         private static void UnloadAll()
         {
-            var oldRoom = FindRoomData();
-            Debug.Log(oldRoom);
-            GameObject.Destroy(oldRoom);
+            foreach (var data in FindAllRoomData())
+            {
+                GameObject.Destroy(data.gameObject);
+            }
         }
 
-        private static GameObject FindRoomData()
-        {
-            return GameObject.FindGameObjectWithTag("RoomData");
-        }
+        private static RoomData[] FindAllRoomData() => GameObject.FindObjectsOfType<RoomData>();
+        private static RoomData FindRoomData() => GameObject.FindObjectOfType<RoomData>();
     }
 }

--- a/Assets/Scripts/Interactables/Tracker.cs
+++ b/Assets/Scripts/Interactables/Tracker.cs
@@ -9,6 +9,7 @@ namespace Com.Technitaur.GreenBean.Interactables
         private struct TrackedObject
         {
             public string name;
+            public Room room;
             public Vector2Int pos;
             public bool isDirty;
         }
@@ -36,7 +37,10 @@ namespace Com.Technitaur.GreenBean.Interactables
             for (int i = 0; i < tracked.Count; i++)
             {
                 var rounded = Vector2Int.RoundToInt(obj.transform.position);
-                if (obj.name == tracked[i].name && rounded == tracked[i].pos)
+                var sameName = obj.name == tracked[i].name;
+                var samePos = rounded == tracked[i].pos;
+                var sameRoom = FindCurrentRoom() == tracked[i].room;
+                if (sameName && samePos)
                     return i;
             }
             return -1;
@@ -48,7 +52,7 @@ namespace Com.Technitaur.GreenBean.Interactables
             var idx = FindIndexOfObject(obj);
             var newObj = NewTrackedObject(obj);
             newObj.isDirty = true;
-            tracked.RemoveAt(idx);
+            if (idx >= 0) tracked.RemoveAt(idx);
             tracked.Add(newObj);
         }
         
@@ -58,7 +62,13 @@ namespace Com.Technitaur.GreenBean.Interactables
             newObj.name = obj.name;
             newObj.pos = Vector2Int.RoundToInt(obj.transform.position);
             newObj.isDirty = false;
+            newObj.room = FindCurrentRoom();
             return newObj;
+        }
+        
+        private Room FindCurrentRoom()
+        {
+            return GameObject.FindObjectOfType<RoomData>().RoomName;
         }
     }
 }


### PR DESCRIPTION
It now uses a room enum to know which room it came from.
This is to prevent items that are in the same place in different rooms from thinking that they are the same item.